### PR TITLE
Configuring-jest.config.js-testmatch-regex

### DIFF
--- a/Web/client/jest.config.js
+++ b/Web/client/jest.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   preset: '@vue/cli-plugin-unit-jest',
-  testMatch: ['<rootDir>/(src/**/spec.(ts|tsx|js)|**/__tests__/*.(ts|tsx|js))']
+  testMatch: [
+    '<rootDir>/(src/**/spec.(ts|tsx|js)|**/__tests__/*.(ts|tsx|js))',
+    '**/__tests__/**/*.[jt]s?(x)',
+    '**/?(*.)+(spec|test).[jt]s?(x)'
+  ]
 }


### PR DESCRIPTION
## Rationale
Changed the jest.config.js on Web application to run tests on Windows machine. I took the regex from jest documentation available at:
https://jestjs.io/docs/en/configuration#testmatch-arraystring

## Advice for Reviewers & Testing Notes

- Please make sure that the tests aren't broken on your machine before approval.

## Screenshots:

na

## Checklist
- [ x] PR your own code before you assign reviewers
