### PR TITLE
Updated Node & NPM dependencies to latest.

### DIFF
--- a/Web/server/.gitignore
+++ b/Web/server/.gitignore
@@ -1,0 +1,2 @@
+# Postman collections & environments
+/postman_tests

--- a/Web/server/back-end/package-lock.json
+++ b/Web/server/back-end/package-lock.json
@@ -484,11 +484,11 @@
       }
     },
     "express-promise-router": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/express-promise-router/-/express-promise-router-3.0.3.tgz",
-      "integrity": "sha1-Xm0ipaPwE9cYMxcv6NereAw/a3A=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/express-promise-router/-/express-promise-router-4.0.1.tgz",
+      "integrity": "sha512-kqan6QuMV7FdfN9b2uYpaKEJnxzfj57voI4IsMjgug5mBc6/hjuvoUT76Z/pvRqID2isl/NygTUe8S2MH2trMg==",
       "requires": {
-        "is-promise": "^2.1.0",
+        "is-promise": "^4.0.0",
         "lodash.flattendeep": "^4.0.0",
         "methods": "^1.0.0"
       }
@@ -731,9 +731,9 @@
       "dev": true
     },
     "is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1056,15 +1056,15 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pg": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.2.1.tgz",
-      "integrity": "sha512-DKzffhpkWRr9jx7vKxA+ur79KG+SKw+PdjMb1IRhMiKI9zqYUGczwFprqy+5Veh/DCcFs1Y6V8lRLN5I1DlleQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.3.0.tgz",
+      "integrity": "sha512-jQPKWHWxbI09s/Z9aUvoTbvGgoj98AU7FDCcQ7kdejupn/TcNpx56v2gaOTzXkzOajmOEJEdi9eTh9cA2RVAjQ==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.2.3",
+        "pg-connection-string": "^2.3.0",
         "pg-pool": "^3.2.1",
-        "pg-protocol": "^1.2.4",
+        "pg-protocol": "^1.2.5",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
@@ -1078,9 +1078,9 @@
       }
     },
     "pg-connection-string": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.2.3.tgz",
-      "integrity": "sha512-I/KCSQGmOrZx6sMHXkOs2MjddrYcqpza3Dtsy0AjIgBr/bZiPJRK9WhABXN1Uy1UDazRbi9gZEzO2sAhL5EqiQ=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.3.0.tgz",
+      "integrity": "sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -1093,9 +1093,9 @@
       "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA=="
     },
     "pg-protocol": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.4.tgz",
-      "integrity": "sha512-/8L/G+vW/VhWjTGXpGh8XVkXOFx1ZDY+Yuz//Ab8CfjInzFkreI+fDG3WjCeSra7fIZwAFxzbGptNbm8xSXenw=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.5.tgz",
+      "integrity": "sha512-1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -1134,9 +1134,9 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.5.tgz",
-      "integrity": "sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.6.tgz",
+      "integrity": "sha512-o2a4gxeFcox+CgB3Ig/kNHBP23PiEXHCXx7pcIIsvzoNz4qv+lKTyiSkjOXIMNUl12MO/mOYl2K6wR9X5K6Plg=="
     },
     "postgres-interval": {
       "version": "1.2.0",

--- a/Web/server/back-end/package.json
+++ b/Web/server/back-end/package.json
@@ -13,9 +13,9 @@
   "dependencies": {
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "express-promise-router": "^3.0.3",
+    "express-promise-router": "^4.0.1",
     "jsonwebtoken": "^8.5.1",
-    "pg": "^8.2.1"
+    "pg": "^8.3.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.4"


### PR DESCRIPTION
## Rationale
As discussed previously, we don't really need to use the LTS so updated Node & all NPM dependencies to latest.